### PR TITLE
Fixed bug with getting incorrect peer name

### DIFF
--- a/luci-proto-amneziawg/Makefile
+++ b/luci-proto-amneziawg/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for AmneziaWG VPN
 LUCI_DESCRIPTION:=Provides support and Web UI for AmneziaWG VPN
-PKG_VERSION:=1.0.20241021
+PKG_VERSION:=1.0.20241022
 LUCI_DEPENDS:=+amneziawg-tools +ucode +luci-lib-uqr
 LUCI_PKGARCH:=all
 

--- a/luci-proto-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
+++ b/luci-proto-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
@@ -76,7 +76,7 @@ const methods = {
 						let peer_name;
 
 						uci.foreach('network', `amneziawg_${last_device}`, (s) => {
-							if (s.public_key == record[1])
+							if (s.public_key == record[1] && s.endpoint_host + ":" + s.endpoint_port == record[3])
 								peer_name = s.description;
 						});
 


### PR DESCRIPTION
1. Fixed bug with getting incorrect peer name
2. Updated `luci-proto-amneziawg` version