### PR TITLE
Fixed bug with incorrect peer name detection

### DIFF
--- a/luci-proto-amneziawg/Makefile
+++ b/luci-proto-amneziawg/Makefile
@@ -2,8 +2,8 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for AmneziaWG VPN
 LUCI_DESCRIPTION:=Provides support and Web UI for AmneziaWG VPN
-PKG_VERSION:=1.0.20241022
-LUCI_DEPENDS:=+amneziawg-tools +ucode +luci-lib-uqr
+PKG_VERSION:=1.0.20241023
+LUCI_DEPENDS:=+amneziawg-tools +ucode +luci-lib-uqr +resolveip
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0

--- a/luci-proto-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
+++ b/luci-proto-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
@@ -15,6 +15,18 @@ function command(cmd) {
 	return trim(popen(cmd)?.read?.('all'));
 }
 
+function checkPeerHost(configHost, configPort, wgHost) {
+	const ips = popen(`resolveip ${configHost} 2>/dev/null`);
+	if (ips) {
+		for (let line = ips.read('line'); length(line); line = ips.read('line')) {
+			const ip =  rtrim(line, '\n');
+			if (ip + ":" + configPort == wgHost) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
 
 const methods = {
 	generatePsk: {
@@ -76,7 +88,7 @@ const methods = {
 						let peer_name;
 
 						uci.foreach('network', `amneziawg_${last_device}`, (s) => {
-							if (s.public_key == record[1] && s.endpoint_host + ":" + s.endpoint_port == record[3])
+							if (!s.disabled && s.public_key == record[1] && checkPeerHost(s.endpoint_host, s.endpoint_port, record[3]))
 								peer_name = s.description;
 						});
 


### PR DESCRIPTION
Fixed bug with incorrect peer name detection on `Status -> AmneziaWG` page when more than one peer with the same public key exist:

1. Peers are now tested not only by public key, but also by enabled/disabled status, peer host (both IP and FQDN are supported) and port.
2. Added required `resolveip` dependency.