### PR TITLE
Update kmod-amneziawg to the latest upstream sources

### DIFF
--- a/kmod-amneziawg/Makefile
+++ b/kmod-amneziawg/Makefile
@@ -2,13 +2,13 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=kmod-amneziawg
-PKG_VERSION:=1.0.20241024
+PKG_VERSION:=1.0.20241119
 PKG_RELEASE:=1
 WIREGUARD_VERSION:=1.0.0
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-linux-kernel-module.git
-PKG_SOURCE_VERSION:=v1.0.20241023
+PKG_SOURCE_VERSION:=7e7dfca6b2824e5a14c5b011a4e05aac89d85231
 PKG_MIRROR_HASH:=skip
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)


### PR DESCRIPTION
`kmod-amneziawg` module updated according to the latest upstream sources: `7e7dfca6b2824e5a14c5b011a4e05aac89d85231` (as of 19.11.2024)