### PR TITLE
Fix incorrect peer name detection when ip v6 is used

### DIFF
--- a/luci-proto-amneziawg/Makefile
+++ b/luci-proto-amneziawg/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for AmneziaWG VPN
 LUCI_DESCRIPTION:=Provides support and Web UI for AmneziaWG VPN
-PKG_VERSION:=1.0.20241026
+PKG_VERSION:=1.0.20241203
 LUCI_DEPENDS:=+amneziawg-tools +ucode +luci-lib-uqr +resolveip
 LUCI_PKGARCH:=all
 

--- a/luci-proto-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
+++ b/luci-proto-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
@@ -17,10 +17,11 @@ function command(cmd) {
 
 function checkPeerHost(configHost, configPort, wgHost) {
 	const ips = popen(`resolveip ${configHost} 2>/dev/null`);
+	const hostIp = replace(wgHost, /\[|\]/g, "");
 	if (ips) {
 		for (let line = ips.read('line'); length(line); line = ips.read('line')) {
 			const ip =  rtrim(line, '\n');
-			if (ip + ":" + configPort == wgHost) {
+			if (ip + ":" + configPort == hostIp) {
 				return true;
 			}
 		}


### PR DESCRIPTION
This PR fixes incorrect peer detection when using IP v6 by deleting all the square the square brackets from the wgHost variable.