### PR TITLE
#27: add extra checks for hostname when building QR

### DIFF
--- a/luci-proto-amneziawg/Makefile
+++ b/luci-proto-amneziawg/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for AmneziaWG VPN
 LUCI_DESCRIPTION:=Provides support and Web UI for AmneziaWG VPN
-PKG_VERSION:=1.0.20250125
+PKG_VERSION:=1.0.20250402
 LUCI_DEPENDS:=+amneziawg-tools +ucode +luci-lib-uqr +resolveip
 LUCI_PKGARCH:=all
 

--- a/luci-proto-amneziawg/htdocs/luci-static/resources/protocol/amneziawg.js
+++ b/luci-proto-amneziawg/htdocs/luci-static/resources/protocol/amneziawg.js
@@ -802,12 +802,12 @@ return network.registerProtocol('amneziawg', {
 				var hostnames = [];
 
 				uci.sections('ddns', 'service', function(s) {
-					if (typeof(s.lookup_host) == 'string' && s.enabled == '1')
+					if (typeof(s?.lookup_host) == 'string' && s?.enabled == '1')
 						hostnames.push(s.lookup_host);
 				});
 
 				uci.sections('system', 'system', function(s) {
-					if (typeof(s.hostname) == 'string' && s.hostname.indexOf('.') > 0)
+					if (typeof(s?.hostname) == 'string' && s?.hostname?.indexOf('.') > 0)
 						hostnames.push(s.hostname);
 				});
 


### PR DESCRIPTION
1. Added extra for hostname when building QR from the upstream project: https://github.com/openwrt/luci/commit/4207c2c5d51470fd273441f92b0a2c104441454c
2. Updated `luci-proto-wireguard` version.