### PR TITLE
#29: fix peer name detection dynamic ip

### DIFF
--- a/luci-proto-amneziawg/Makefile
+++ b/luci-proto-amneziawg/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for AmneziaWG VPN
 LUCI_DESCRIPTION:=Provides support and Web UI for AmneziaWG VPN
-PKG_VERSION:=1.0.20250402
+PKG_VERSION:=1.0.20250414
 LUCI_DEPENDS:=+amneziawg-tools +ucode +luci-lib-uqr +resolveip
 LUCI_PKGARCH:=all
 

--- a/luci-proto-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
+++ b/luci-proto-amneziawg/root/usr/share/rpcd/ucode/luci.amneziawg
@@ -89,11 +89,16 @@ const methods = {
 					}
 					else {
 						let peer_name;
+						let peer_name_legacy;
 
 						uci.foreach('network', `amneziawg_${last_device}`, (s) => {
 							if (!s.disabled && s.public_key == record[1] && (!s.endpoint_host || checkPeerHost(s.endpoint_host, s.endpoint_port, record[3])))
 								peer_name = s.description;
+							if (s.public_key == record[1])
+								peer_name_legacy = s.description;
 						});
+
+						if (!peer_name) peer_name = peer_name_legacy;
 
 						const peer = {
 							name: peer_name,


### PR DESCRIPTION
Added a fallback to a legacy peer name detection algorithm to fix incorrect peer name detection if a peer host is defined as a hostname and has a dynamic IP