### PR TITLE
#95: update upstream sources to fix keepalive packets being ignored

### DIFF
--- a/amneziawg-go/Makefile
+++ b/amneziawg-go/Makefile
@@ -3,13 +3,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=amneziawg-go
-PKG_VERSION:=3.0.0
+PKG_VERSION:=3.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-go.git
-# Reference: v3.0.3
-PKG_SOURCE_VERSION:=cf9d2dd202821301f7039093b0a1b3d4b574c47c
+# Reference: master
+PKG_SOURCE_VERSION:=08d68cdae27762c3e07f36bbb12d2bad32f81926
 PKG_MIRROR_HASH:=skip
 
 PKG_BUILD_DEPENDS:=golang/host

--- a/amneziawg-tools/Makefile
+++ b/amneziawg-tools/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=amneziawg-tools
-PKG_VERSION:=3.0.0
+PKG_VERSION:=3.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-tools.git
-# Reference: v3.0.20260730
-PKG_SOURCE_VERSION:=d09ecc38425082e472368dd2bf8c4c42d10cae03
+# Reference: master
+PKG_SOURCE_VERSION:=9f70177d204d5be66c5b043518a57b7d62b3f9d1
 PKG_MIRROR_HASH:=skip
 
 PKG_LICENSE:=GPL-2.0

--- a/kmod-amneziawg/Makefile
+++ b/kmod-amneziawg/Makefile
@@ -2,14 +2,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=kmod-amneziawg
-PKG_VERSION:=3.0.0
+PKG_VERSION:=3.0.1
 PKG_RELEASE:=1
 WIREGUARD_VERSION:=1.0.0
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-linux-kernel-module.git
-# Reference: v3.0.20260731-04
-PKG_SOURCE_VERSION:=c78a89ee1945d24c6e9c21a442aae87be059a6ca
+# Reference: master
+PKG_SOURCE_VERSION:=ce163101dbcddfb64631f5fea52252ea836372b5
 PKG_MIRROR_HASH:=skip
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)

--- a/luci-proto-amneziawg/Makefile
+++ b/luci-proto-amneziawg/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for AmneziaWG VPN
 LUCI_DESCRIPTION:=Provides support and Web UI for AmneziaWG VPN
-PKG_VERSION:=3.0.0
+PKG_VERSION:=3.0.1
 LUCI_DEPENDS:=+amneziawg-tools +ucode +luci-lib-uqr +resolveip
 LUCI_PKGARCH:=all
 


### PR DESCRIPTION
amneziawg-go, amneziawg-tools, kmod-amneziawg: update upstream sources to fix keepalive packets being ignored
luci-proto-amneziawg: bump version