### PR TITLE
#97: AmneziaWG 3.1 support

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -132,7 +132,7 @@ jobs:
 
           # The kernel module can only be installed on a firmware whose kernel
           # reports the very same vermagic, which matters for SNAPSHOT builds.
-          vermagic="$(find openwrt/build_dir -maxdepth 4 -type f -name vermagic -print -quit)"
+          vermagic="$(find openwrt/build_dir -maxdepth 5 -type f -name '.vermagic' -print -quit)"
           {
             echo "YAAWG version: ${{ inputs.amneziawg_version }}"
             echo "OpenWrt version: ${{ inputs.openwrt_version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
   push:
     tags:
       - "v*"
+  schedule:
+    # Once a day check whether a newer stable OpenWrt release appeared and, if
+    # so, build the latest published YAAWG release for it and attach the
+    # archives to that release. Nothing happens when everything is up to date.
+    - cron: "0 5 * * *"
   workflow_dispatch:
     inputs:
       amneziawg_version:
@@ -54,12 +59,16 @@ jobs:
       amneziawg_version: ${{ steps.params.outputs.amneziawg_version }}
       publish: ${{ steps.params.outputs.publish }}
       draft: ${{ steps.params.outputs.draft }}
+      skip: ${{ steps.params.outputs.skip }}
     steps:
       - name: Checkout YAAWG repository
         uses: actions/checkout@v5
 
       - name: Resolve parameters
         id: params
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -e -o pipefail
 
@@ -79,19 +88,54 @@ jobs:
           fi
           echo "openwrt_version=$requested" >> "$GITHUB_OUTPUT"
 
+          # `skip' short-circuits the build and publish jobs when there is
+          # nothing to do (used by the daily scheduled run).
+          skip=false
+
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "amneziawg_version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
             echo "publish=true" >> "$GITHUB_OUTPUT"
             echo "draft=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            # Find the latest published (non-draft, non-prerelease) YAAWG
+            # release. The `snapshot' pre-release is skipped on purpose. The
+            # first page of the releases API (newest first) is more than enough.
+            tag=$(gh api "repos/${GH_REPO}/releases" \
+              --jq '[.[] | select(.draft == false and .prerelease == false)][0].tag_name')
+
+            if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+              echo "No published stable release to update; nothing to do."
+              skip=true
+              echo "amneziawg_version=master" >> "$GITHUB_OUTPUT"
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "draft=false" >> "$GITHUB_OUTPUT"
+            else
+              # The archives carry the OpenWrt version in their name, so their
+              # presence tells whether this release was already built for it.
+              if gh release view "$tag" --json assets \
+                --jq '.assets[].name' \
+                | grep -q -- "-openwrt-${requested}\.tar\.gz$"; then
+                echo "Release $tag already has packages for OpenWrt $requested; nothing to do."
+                skip=true
+              else
+                echo "Building release $tag for the new OpenWrt $requested."
+              fi
+              echo "amneziawg_version=$tag" >> "$GITHUB_OUTPUT"
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              echo "draft=false" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "amneziawg_version=${{ inputs.amneziawg_version }}" >> "$GITHUB_OUTPUT"
             echo "publish=${{ inputs.publish }}" >> "$GITHUB_OUTPUT"
             echo "draft=${{ inputs.draft }}" >> "$GITHUB_OUTPUT"
           fi
 
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build
     needs: prepare
+    if: ${{ needs.prepare.outputs.skip != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -107,7 +151,7 @@ jobs:
   publish:
     name: Publish release
     needs: [ prepare, build ]
-    if: ${{ needs.prepare.outputs.publish == 'true' }}
+    if: ${{ needs.prepare.outputs.publish == 'true' && needs.prepare.outputs.skip != 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Download artifacts

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A: Prebuilt packages for the most popular architectures are published on the [releases page](../../releases): a versioned release for the latest stable OpenWRT version and a daily refreshed `snapshot` pre-release for `SNAPSHOT`. If your architecture is not covered, [build it yourself](#how-to-use-the-new-workflow).
 
 **Q: What is the latest supported version of the protocol?**  
-A: YAAWG fully supports AmneziaWG v3.0, including header protection, content padding and the customizable timings, on top of everything v2.0 offers (S3-S4, I1-I5 and ranged H1-H4 parameters). See the [protocol parameters](#protocol-parameters) section.
+A: YAAWG fully supports AmneziaWG v3.1, adding random packet trailers and the option to disable cookie replies on top of the v3.0 header protection, content padding and customizable timings, and everything v2.0 offers (S3-S4, I1-I5 and ranged H1-H4 parameters). See the [protocol parameters](#protocol-parameters) section.
 
 **Q: Should I use the kernel module or the Go implementation?**  
 A: Use the kernel module by default. If it doesn't work for you, switch to the Go implementation. More info [here](#kmod-amneziawg-vs-amneziawg-go).
@@ -40,7 +40,9 @@ The main differences and objectives are:
    - Added support for ranged H1-H4 parameters (delimiter: `-`, e.g., `123456-123500`), including a check that the four ranges do not overlap each other.
    - Added support for v2.0 protocol parameters: S3-S4, I1-I5.
    - Added support for v3.0 protocol parameters, ranged `Persistent Keep Alive` and a generator for the header protection key.
+   - Added support for v3.1 protocol parameters: the `Random Trailers` and `Disable Cookies` interface checkboxes.
    - The AmneziaWG parameters are now described by a single table, so the settings tab, the configuration import and the configuration export can never drift apart.
+   - The exported peer QR code is now bounded so that even a long v3.1 configuration always scales down to fit the page instead of getting cut off.
 
 2. `amneziawg-tools` has been aligned with the upstream repository [amneziawg-tools](https://github.com/amnezia-vpn/amneziawg-tools/):
    - The package is now compiled based on the upstream repository.
@@ -51,13 +53,16 @@ The main differences and objectives are:
    - Added support for ranged H1-H4 parameters (with `-` delimiter, e.g., `123456-123500`).
    - Added support for v2.0 protocol parameters: S3-S4, I1-I5.
    - Added support for v3.0 protocol parameters and ranged `PersistentKeepalive`.
+   - Added support for v3.1 protocol parameters: `RandomTrailers` and `DisableCookies` on the interface.
 
 3. `kmod-amneziawg` is now compiled entirely based on the upstream [amneziawg-linux-kernel-module](https://github.com/amnezia-vpn/amneziawg-linux-kernel-module) repository.
    - Added support for v2.0 protocol parameters: S3-S4, I1-I5.
    - Added support for v3.0 protocol parameters.
+   - Added support for v3.1 protocol parameters.
 
 4. `amneziawg-go` acts as an alternative to `kmod-amneziawg`. Please refer to [this section](#kmod-amneziawg-vs-amneziawg-go) for more information. The Go implementation is fully based on the upstream project [amneziawg-go](https://github.com/amnezia-vpn/amneziawg-go).
    - Added support for v3.0 protocol parameters.
+   - Added support for v3.1 protocol parameters.
 
 5. Packaging and build process:
    - Prebuilt packages for the most popular architectures are published automatically, see [below](#download-prebuilt-amneziawg-packages).
@@ -123,19 +128,35 @@ How to use them:
 3. **Timings** change how often a client rekeys, retries and sends keep alives. Because they only alter local behaviour, they are the safest parameters to experiment with: use ranges to avoid a regular, easily recognizable traffic pattern. Note that a `RejectAfterTime` shorter than `RekeyAfterTime` makes the tunnel stall.
 4. **Ranged `Persistent Keep Alive`** serves the same purpose for the keep alive interval of a single peer.
 
+### Parameters of AmneziaWG v3.1
+
+v3.1 adds three **boolean** parameters. In a text configuration file a boolean is written as `on`/`off` (the canonical form emitted by `awg showconf`) or as `1`/`0`; the words `true`/`false` are **not** accepted. In LuCI they are simple checkboxes, and YAAWG writes the enabled state as `on` and omits the parameter entirely when it is left off.
+
+| UCI option | Configuration file key | Side | Description |
+| --- | --- | --- | --- |
+| `awg_random_trailers` | `RandomTrailers` | server | Appends a random-length trailer of extra bytes to packets so their on-wire size varies and cannot be fingerprinted. Must be enabled on both ends of the tunnel. |
+| `awg_disable_cookies` | `DisableCookies` | server | Stops sending the WireGuard cookie reply messages, removing a distinctive packet type used under load. Meant to be enabled on both ends. |
+
+How to use them:
+
+1. **Random trailers** hide the exact packet length. Because a receiver only accepts oversized packets when it, too, has the option enabled, it changes the wire format and must be set on both ends.
+2. **Disable cookies** removes the cookie reply, one of the last fixed WireGuard message types. Enable it on both ends so that neither side expects the cookie handshake.
+
+> The v3.1 protocol also defines a per-peer `AdvancedSecurity` flag. It is not exposed by YAAWG yet, because the current kernel module and Go implementation do not act on it; it will be added once they gain real support for it.
+
 ### Backward compatibility
 
-AmneziaWG v3.0 is a superset of the previous versions, and both `kmod-amneziawg` and `amneziawg-go` keep supporting everything that came before:
+AmneziaWG v3.1 is a superset of the previous versions, and both `kmod-amneziawg` and `amneziawg-go` keep supporting everything that came before:
 
-1. With all parameters left empty, an AmneziaWG v3.0 interface is indistinguishable from plain WireGuard and interoperates with WireGuard peers.
+1. With all parameters left empty, an AmneziaWG v3.1 interface is indistinguishable from plain WireGuard and interoperates with WireGuard peers.
 2. With only the v1.5 and v2.0 parameters filled in, it behaves exactly like an AmneziaWG v1.5 or v2.0 interface and interoperates with peers running those versions. Existing configurations therefore keep working after the upgrade and require no changes.
-3. The client-side v3.0 parameters (the timings and the ranged `Persistent Keep Alive`) may be used against a v2.0 peer, since they never change the wire format.
-4. The server-side v3.0 parameters (`HeaderProtectionKey`, `ContentPaddingAddition`) do change the wire format, so both ends must run AmneziaWG v3.0. A v2.0 peer will silently drop the packets it cannot parse.
-5. Always upgrade `amneziawg-tools` together with `kmod-amneziawg` or `amneziawg-go`. The v3.0 tools only pass a parameter down to the implementation when it is actually configured, so an older kernel module keeps working as long as the v3.0 parameters are empty, but starts to fail with `Unable to modify interface` once they are set.
+3. The client-side timing parameters (the v3.0 timings and the ranged `Persistent Keep Alive`) may be used against an older peer, since they never change the wire format.
+4. The server-side parameters that change the wire format (`HeaderProtectionKey`, `ContentPaddingAddition` from v3.0 and `RandomTrailers`, `DisableCookies` from v3.1) must be set identically on both ends. A peer that does not enable them will silently drop the packets it cannot parse.
+5. Always upgrade `amneziawg-tools` together with `kmod-amneziawg` or `amneziawg-go`. The tools only pass a parameter down to the implementation when it is actually configured, so an older kernel module keeps working as long as the newer parameters are empty, but starts to fail with `Unable to modify interface` once they are set.
 
 ## `kmod-amneziawg` vs `amneziawg-go`
 
-When the AmneziaWG authors introduced the v1.5 protocol, it was supported only in the Go implementation. Thus the user namespace (Go) implementation was added to the repo in order to support the newer protocol version. Later, v2.0 and v3.0 protocol support was added to both the user namespace (Go) and kernel module implementations. To maintain backward compatibility, this repository will continue to support both packages.
+When the AmneziaWG authors introduced the v1.5 protocol, it was supported only in the Go implementation. Thus the user namespace (Go) implementation was added to the repo in order to support the newer protocol version. Later, v2.0, v3.0 and v3.1 protocol support was added to both the user namespace (Go) and kernel module implementations. To maintain backward compatibility, this repository will continue to support both packages.
 
 Differences:
 1. `kmod-amneziawg`: requires a less powerful device to run, consumes less space and provides a faster throughput. Recommended option.
@@ -189,7 +210,7 @@ The most popular architectures are built automatically and published on the [rel
 
 Two workflows keep those artifacts up to date, and both of them can also be started by hand from a fork:
 
-1. `Release - Build AmneziaWG for the latest OpenWrt release` runs whenever a `vX.Y.Z` tag is pushed. It resolves the newest stable OpenWRT version on its own and collects the packages into a **draft** release, so that the changelog can be written before it goes public. Started by hand against an already published release, it only adds the new archives to it, which is how an unchanged YAAWG version is rebuilt for a freshly released OpenWRT version.
+1. `Release - Build AmneziaWG for the latest OpenWrt release` runs whenever a `vX.Y.Z` tag is pushed. It resolves the newest stable OpenWRT version on its own and collects the packages into a draft release, so that the changelog can be written before it goes public. Started by hand against an already published release, it only adds the new archives to it, which is how an unchanged YAAWG version is rebuilt for a freshly released OpenWRT version. The same workflow also runs once a day on a schedule: it looks up the newest stable OpenWRT version and the latest published YAAWG release, and if that release does not yet contain archives for that OpenWRT version it builds them and attaches them automatically. When everything is already up to date the scheduled run does nothing, so new OpenWRT releases are covered without any manual tracking.
 2. `Snapshot - Build AmneziaWG for OpenWrt SNAPSHOT` runs daily and republishes the rolling `snapshot` pre-release.
 
 Every archive is named `amneziawg-{target}-{subtarget}-{architecture}-openwrt-{OpenWRT version}.tar.gz`, so builds of the same YAAWG version for several OpenWRT versions can live side by side in one release.
@@ -287,6 +308,6 @@ Steps:
 > **Note:** You may need to clear your browser cache to see the new protocol available in OpenWRT.
 
 #### Vermagic control for `SNAPSHOT` versions
-> **Note:** Vermagic is calculated only for the **old workflow**
+> **Note:** The prebuilt `release` and `snapshot` archives record the `vermagic` in `build-info.txt`. Among the compile-it-yourself workflows only the **legacy** one computes it; the `New - Build AmneziaWG from SDK` workflow does not.
 
-Vermagic is a hash calculated for the OpenWRT kernel. When installing kernel-related packages, OpenWRT checks if the package's `vermagic` matches the kernel's. If not, installation won't succeed. Since `SNAPSHOT` versions update daily, `vermagic` values may differ. Check your firmware's `vermagic` by running `apk info kernel` or `opkg info kernel` and noting the hash after the kernel version in `Version`. For example, `6.6.52~f58afd3748410d3b1baa06a466d6682-r1` means `vermagic` is `f58afd3748410d3b1baa06a466d6682`. The compiled package's `vermagic` value is located in the `vermagic` file within the workflow artifacts. If these do not match, the kernel module cannot be installed.
+Vermagic is a hash calculated for the OpenWRT kernel. When installing kernel-related packages, OpenWRT checks if the package's `vermagic` matches the kernel's. If not, installation won't succeed. Since `SNAPSHOT` versions update daily, `vermagic` values may differ. Check your firmware's `vermagic` by running `apk info kernel` or `opkg info kernel` and noting the hash after the kernel version in `Version`. For example, `6.6.52~f58afd3748410d3b1baa06a466d6682-r1` means `vermagic` is `f58afd3748410d3b1baa06a466d6682`. For the prebuilt archives the compiled package's `vermagic` value is recorded on the `Vermagic:` line of `build-info.txt`; in the legacy workflow it is placed in a separate `vermagic` file within the artifacts. If these do not match, the kernel module cannot be installed.

--- a/amneziawg-go/Makefile
+++ b/amneziawg-go/Makefile
@@ -3,13 +3,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=amneziawg-go
-PKG_VERSION:=3.0.1
+PKG_VERSION:=3.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-go.git
 # Reference: master
-PKG_SOURCE_VERSION:=08d68cdae27762c3e07f36bbb12d2bad32f81926
+PKG_SOURCE_VERSION:=1b86b2ae0e493e7ea93f8c1a0f0cb6735b1551f1
 PKG_MIRROR_HASH:=skip
 
 PKG_BUILD_DEPENDS:=golang/host

--- a/amneziawg-tools/Makefile
+++ b/amneziawg-tools/Makefile
@@ -1,13 +1,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=amneziawg-tools
-PKG_VERSION:=3.0.1
+PKG_VERSION:=3.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-tools.git
 # Reference: master
-PKG_SOURCE_VERSION:=9f70177d204d5be66c5b043518a57b7d62b3f9d1
+PKG_SOURCE_VERSION:=ee0f0a9aa34ff0a0da4b3433b9512781cfe02843
 PKG_MIRROR_HASH:=skip
 
 PKG_LICENSE:=GPL-2.0

--- a/amneziawg-tools/files/amneziawg.sh
+++ b/amneziawg-tools/files/amneziawg.sh
@@ -46,6 +46,16 @@ awg_keepalive_timeout:KeepaliveTimeout
 awg_max_handshake_attempts:MaxHandshakeAttempts
 "
 
+# Boolean AmneziaWG interface parameters (AmneziaWG 3.1), in the same
+# `<uci option>:<configuration file key>' notation. They are stored as UCI
+# flags and only written to the configuration file when enabled, so that the
+# key is passed down to the implementation exclusively when the user turns it
+# on. `awg' accepts `on'/`off' as well as `1'/`0'; the canonical `on' is used.
+AWG_BOOL_PARAMS="
+awg_random_trailers:RandomTrailers
+awg_disable_cookies:DisableCookies
+"
+
 proto_amneziawg_init_config() {
 	proto_config_add_string "private_key"
 	proto_config_add_int "listen_port"
@@ -75,6 +85,9 @@ proto_amneziawg_init_config() {
 	proto_config_add_string "awg_reject_after_time"
 	proto_config_add_string "awg_keepalive_timeout"
 	proto_config_add_string "awg_max_handshake_attempts"
+	# AmneziaWG 3.1 boolean parameters
+	proto_config_add_boolean "awg_random_trailers"
+	proto_config_add_boolean "awg_disable_cookies"
 # shellcheck disable=SC2034
 	available=1
 # shellcheck disable=SC2034
@@ -193,6 +206,13 @@ proto_amneziawg_write_params() {
 		config_get value "${config}" "${option}"
 
 		[ -n "${value}" ] && echo "${param##*:}=${value}" >> "${awg_cfg}"
+	done
+
+	for param in ${AWG_BOOL_PARAMS}; do
+		option="${param%%:*}"
+		config_get_bool value "${config}" "${option}" 0
+
+		[ "${value}" = "1" ] && echo "${param##*:}=on" >> "${awg_cfg}"
 	done
 
 	return 0

--- a/kmod-amneziawg/Makefile
+++ b/kmod-amneziawg/Makefile
@@ -2,14 +2,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=kmod-amneziawg
-PKG_VERSION:=3.0.1
+PKG_VERSION:=3.1.0
 PKG_RELEASE:=1
 WIREGUARD_VERSION:=1.0.0
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-linux-kernel-module.git
 # Reference: master
-PKG_SOURCE_VERSION:=ce163101dbcddfb64631f5fea52252ea836372b5
+PKG_SOURCE_VERSION:=46803204e7ec3b068199cd671143bec661d3fe21
 PKG_MIRROR_HASH:=skip
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)

--- a/luci-proto-amneziawg/htdocs/luci-static/resources/protocol/amneziawg.js
+++ b/luci-proto-amneziawg/htdocs/luci-static/resources/protocol/amneziawg.js
@@ -177,8 +177,32 @@ const awgOptions = [
 		name: 'awg_max_handshake_attempts', key: 'MaxHandshakeAttempts', title: _('Max Handshake Attempts'),
 		descr: _('AmneziaWG 3.0. Number of handshake retries before giving up. A single value or a <em>low-high</em> range. Default is 18.'),
 		validate: validateU16Range, placeholder: '18'
+	},
+
+	/* AmneziaWG 3.1. Boolean parameters, rendered as checkboxes and written to
+	   the configuration file as `on'/`off'. */
+	{
+		name: 'awg_random_trailers', key: 'RandomTrailers', title: _('Random Trailers'),
+		descr: _('AmneziaWG 3.1. Append a random length trailer of extra bytes to packets so their size varies. Must be enabled on both ends of the tunnel.'),
+		flag: true
+	},
+	{
+		name: 'awg_disable_cookies', key: 'DisableCookies', title: _('Disable Cookies'),
+		descr: _('AmneziaWG 3.1. Stop sending the WireGuard cookie reply messages, removing a distinctive packet type. Meant to be enabled on both ends of the tunnel.'),
+		flag: true
 	}
 ];
+
+/* AmneziaWG boolean parameters are written as `on'/`off' (or `1'/`0') in the
+   configuration file but stored as an UCI flag (`1'/`'') in LuCI. These helpers
+   translate between the two representations. */
+function awgFlagToUci(value) {
+	return /^(on|1|true|yes)$/i.test(String(value ?? '').trim()) ? '1' : '';
+}
+
+function awgFlagToConfig(value) {
+	return (value == '1') ? 'on' : 'off';
+}
 
 var stubValidator = {
 	factory: validation,
@@ -202,7 +226,7 @@ function buildSVGQRCode(data, code) {
 	};
 	const svg = uqr.renderSVG(data, options);
 	code.style.opacity = '';
-	dom.content(code, Object.assign(E(svg), { style: 'width:100%;height:auto' }));
+	dom.content(code, Object.assign(E(svg), { style: 'width:100%;height:auto;max-width:100%;display:block;margin:0 auto' }));
 }
 
 var cbiKeyPairGenerate = form.DummyValue.extend({
@@ -347,7 +371,7 @@ return network.registerProtocol('amneziawg', {
 		catch(e) {}
 
 		for (let awgOption of awgOptions) {
-			o = s.taboption('amneziawg', form.Value, awgOption.name, awgOption.title, awgOption.descr);
+			o = s.taboption('amneziawg', awgOption.flag ? form.Flag : form.Value, awgOption.name, awgOption.title, awgOption.descr);
 			o.optional = true;
 
 			if (awgOption.datatype)
@@ -519,8 +543,11 @@ return network.registerProtocol('amneziawg', {
 					s.getOption('listen_port').getUIElement(s.section).setValue(config.interface_listenport || '');
 					s.getOption('addresses').getUIElement(s.section).setValue(config.interface_address);
 
-					for (let awgOption of awgOptions)
-						s.getOption(awgOption.name).getUIElement(s.section).setValue(config['interface_' + awgOption.key.toLowerCase()] || '');
+					for (let awgOption of awgOptions) {
+						const imported = config['interface_' + awgOption.key.toLowerCase()] || '';
+						s.getOption(awgOption.name).getUIElement(s.section).setValue(
+							awgOption.flag ? awgFlagToUci(imported) : imported);
+					}
 
 					if (config.interface_dns)
 						s.getOption('dns').getUIElement(s.section).setValue(config.interface_dns);
@@ -569,6 +596,7 @@ return network.registerProtocol('amneziawg', {
 							uci.set('network', sid, 'preshared_key', pconf.peer_presharedkey);
 							uci.set('network', sid, 'allowed_ips', pconf.peer_allowedips);
 							uci.set('network', sid, 'persistent_keepalive', pconf.peer_persistentkeepalive);
+
 							break;
 						}
 					}
@@ -856,6 +884,11 @@ return network.registerProtocol('amneziawg', {
 			const awg = awgOptions.map(function(awgOption) {
 				const value = s.formvalue(s.section, awgOption.name);
 
+				if (awgOption.flag)
+					return (value == '1')
+						? '%s = %s'.format(awgOption.key, awgFlagToConfig(value))
+						: '# %s not defined'.format(awgOption.key);
+
 				return value
 					? '%s = %s'.format(awgOption.key, value)
 					: '# %s not defined'.format(awgOption.key);
@@ -981,7 +1014,11 @@ return network.registerProtocol('amneziawg', {
 					}, [
 						E('div', {
 							'class': 'qr-code',
-							'style': 'text-align:center'
+							// Bound the QR code so that even a long AmneziaWG
+							// configuration scales down to fit and never overflows
+							// the page: full width on narrow screens, capped at
+							// 320px next to the textual configuration otherwise.
+							'style': 'text-align:center;flex:0 0 auto;width:min(100%, 320px);max-width:100%'
 						}, [
 							E('em', { 'class': 'spinning' }, [ _('Generating QR code…') ])
 						]),

--- a/luci-proto-amneziawg/po/ru/amneziawg.po
+++ b/luci-proto-amneziawg/po/ru/amneziawg.po
@@ -264,3 +264,23 @@ msgstr ""
 
 msgid "Download peer configuration file"
 msgstr "Скачать файл конфигурации пира"
+
+msgid "Random Trailers"
+msgstr "Случайные хвосты"
+
+msgid ""
+"AmneziaWG 3.1. Append a random length trailer of extra bytes to packets so "
+"their size varies. Must be enabled on both ends of the tunnel."
+msgstr ""
+"AmneziaWG 3.1. Добавляет к пакетам хвост случайной длины из лишних байтов, "
+"чтобы их размер менялся. Должно быть включено на обеих сторонах туннеля."
+
+msgid "Disable Cookies"
+msgstr "Отключить cookie"
+
+msgid ""
+"AmneziaWG 3.1. Stop sending the WireGuard cookie reply messages, removing a "
+"distinctive packet type. Meant to be enabled on both ends of the tunnel."
+msgstr ""
+"AmneziaWG 3.1. Прекращает отправку ответных cookie-сообщений WireGuard, убирая "
+"характерный тип пакетов. Предполагается включение на обеих сторонах туннеля."


### PR DESCRIPTION
Workflows:
- Add shcedule check for a new stable version of the OpenWRT and build fresh binaries if found.

kmod-amneziawg:
- update upstream to support AmneziaWG 3.1

amneziawg-go:
- update upstream to support AmneziaWG 3.1

amneziawg-tools:
- update upstream to support AmneziaWG 3.1
- add support for AmneziaWG 3.1 parameters

luci-proto-amneziawg:
- add support for AmneziaWG 3.1 parameters
- fix QR-code display for configs with a lot of parameters
- add translation (AI generated)

readme:
- readme update to reflect changes