### PR TITLE
#99: update upstream code (kmod + go)

### DIFF
--- a/amneziawg-go/Makefile
+++ b/amneziawg-go/Makefile
@@ -3,13 +3,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=amneziawg-go
-PKG_VERSION:=3.1.0
+PKG_VERSION:=3.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-go.git
 # Reference: master
-PKG_SOURCE_VERSION:=1b86b2ae0e493e7ea93f8c1a0f0cb6735b1551f1
+PKG_SOURCE_VERSION:=b5928efb6ca19f0153958460c3d141f04abc5c2e
 PKG_MIRROR_HASH:=skip
 
 PKG_BUILD_DEPENDS:=golang/host

--- a/amneziawg-tools/Makefile
+++ b/amneziawg-tools/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=amneziawg-tools
-PKG_VERSION:=3.1.0
+PKG_VERSION:=3.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git

--- a/kmod-amneziawg/Makefile
+++ b/kmod-amneziawg/Makefile
@@ -2,14 +2,14 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=kmod-amneziawg
-PKG_VERSION:=3.1.0
+PKG_VERSION:=3.1.1
 PKG_RELEASE:=1
 WIREGUARD_VERSION:=1.0.0
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/amnezia-vpn/amneziawg-linux-kernel-module.git
 # Reference: master
-PKG_SOURCE_VERSION:=46803204e7ec3b068199cd671143bec661d3fe21
+PKG_SOURCE_VERSION:=3c38e168beb7c60dec41dfe423d41555205a3dac
 PKG_MIRROR_HASH:=skip
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)

--- a/luci-proto-amneziawg/Makefile
+++ b/luci-proto-amneziawg/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for AmneziaWG VPN
 LUCI_DESCRIPTION:=Provides support and Web UI for AmneziaWG VPN
-PKG_VERSION:=3.0.1
+PKG_VERSION:=3.1.1
 LUCI_DEPENDS:=+amneziawg-tools +ucode +luci-lib-uqr +resolveip
 LUCI_PKGARCH:=all
 


### PR DESCRIPTION
kmod-amneziawg:
Sync with upstream to address the following issues:
- fix: initialize header_protection.lock, use down_write in set_key
- socket, compat: fix build with kernel 7.1.5+
- netlink: use strscpy instead of strncpy
- device: pass WQ_PERCPU to avoid splat on kernel 7.2
- fix: use udp window for RandomPaddingAddition
- fix: disable the whole underload if DisableCookies is on

amneziawg-go:
Sync with upstream to address the following issues:
- fix: disable the whole underload if DisableCookies is on
- fix: use udp window for RandomPaddingAddition

amneziawg-tools:
- bump version

luci-proto-amneziawg:
- bump version