### PR TITLE
#99: fix Go version and vermagic calculation

### DIFF
--- a/.github/workflows/build-amneziawg-from-cache.yml
+++ b/.github/workflows/build-amneziawg-from-cache.yml
@@ -89,7 +89,35 @@ jobs:
       run: |
         set -e -x
         mkdir awgrelease
-        echo "vermagic=$(cat openwrt/build_dir/target-${{ inputs.openwrt_arch }}*/linux-${{ inputs.openwrt_target }}_${{ inputs.openwrt_subtarget }}/linux-*/.vermagic)" > awgrelease/vermagic
+
+        # The kernel module can only be installed on a firmware whose kernel
+        # reports the very same vermagic. Let's calculate it.
+        vermagic=""
+        vermagic_file="$(find openwrt/build_dir -maxdepth 5 -type f -name '.vermagic' -print -quit)"
+        if [ -n "$vermagic_file" ]; then
+          vermagic="$(cat "$vermagic_file")"
+        fi
+        if [ -z "$vermagic" ]; then
+          vermagic="$(sed -n 's/.*LINUX_VERMAGIC),\([^,)]*\))[[:space:]]*$/\1/p' openwrt/include/kernel.mk | head -n1)"
+        fi
+        [ -n "$vermagic" ] || vermagic="unknown"
+
+        # AmneziaWG version calculation
+        awg_version=""
+        awg_makefile="$(find openwrt/feeds openwrt/package -maxdepth 4 -type f -path '*kmod-amneziawg/Makefile' -print -quit 2>/dev/null)"
+        if [ -n "$awg_makefile" ]; then
+          awg_version="$(sed -n 's/^PKG_VERSION:=//p' "$awg_makefile" | head -n1)"
+        fi
+        [ -n "$awg_version" ] || awg_version="unknown"
+
+        {
+          echo "YAAWG version: $awg_version"
+          echo "OpenWrt version: ${{ inputs.openwrt_version }}"
+          echo "Target: ${{ inputs.openwrt_target }}/${{ inputs.openwrt_subtarget }}"
+          echo "Architecture: ${{ inputs.openwrt_arch }}"
+          echo "Built at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          echo "Vermagic: $vermagic"
+        } > awgrelease/build-info.txt
         if [ "${{ env.compile_kmod }}" = "true" ]; then
           find "openwrt/bin/targets/${{ inputs.openwrt_target }}/${{ inputs.openwrt_subtarget }}/packages" -maxdepth 1 -type f -name 'kmod-amneziawg*' -exec cp {} awgrelease \;
         fi

--- a/.github/workflows/build-amneziawg-from-sdk.yml
+++ b/.github/workflows/build-amneziawg-from-sdk.yml
@@ -99,9 +99,18 @@ jobs:
         echo "CONFIG_PACKAGE_amneziawg-go=y" >> openwrt/.config
         echo "CONFIG_PACKAGE_amneziawg-tools=y" >> openwrt/.config
         echo "CONFIG_PACKAGE_luci-proto-amneziawg=y" >> openwrt/.config
+        # amneziawg-go requires Go >= 1.25. Only override the SDK's Go feed when
+        # it is actually too old.
         if [ "${{ env.compile_go }}" = "true" ]; then
-          rm -r openwrt/feeds/packages/lang/golang
-          cp -r packages/lang/golang openwrt/feeds/packages/lang
+          sdk_go=$(sed -n 's/^GO_DEFAULT_VERSION:=//p' openwrt/feeds/packages/lang/golang/golang-values.mk)
+          need_go=1.25
+          if [ -n "$sdk_go" ] && [ "$(printf '%s\n%s\n' "$need_go" "$sdk_go" | sort -V | head -n1)" != "$need_go" ]; then
+            echo "SDK ships Go $sdk_go (< $need_go); overriding golang feed from openwrt/packages."
+            rm -r openwrt/feeds/packages/lang/golang
+            cp -r packages/lang/golang openwrt/feeds/packages/lang
+          else
+            echo "SDK ships Go ${sdk_go:-unknown} (>= $need_go); keeping the SDK golang feed."
+          fi
         fi
         ./openwrt/scripts/feeds install -a
         make -C openwrt defconfig
@@ -128,6 +137,27 @@ jobs:
         mkdir awgrelease
         find "openwrt/bin/targets/${{ inputs.openwrt_target }}/${{ inputs.openwrt_subtarget }}/packages" -maxdepth 1 -type f -name 'kmod-amneziawg*' -exec cp {} awgrelease \;
         find "openwrt/bin/packages/${{ inputs.openwrt_arch }}/awgopenwrt" -maxdepth 1 -type f \( -name '*.ipk' -o -name '*.apk' \) -exec cp {} awgrelease \;
+
+        # The kernel module can only be installed on a firmware whose kernel
+        # reports the very same vermagic. Let's calculate it
+        vermagic=""
+        vermagic_file="$(find openwrt/build_dir -maxdepth 5 -type f -name '.vermagic' -print -quit)"
+        if [ -n "$vermagic_file" ]; then
+          vermagic="$(cat "$vermagic_file")"
+        fi
+        if [ -z "$vermagic" ]; then
+          vermagic="$(sed -n 's/.*LINUX_VERMAGIC),\([^,)]*\))[[:space:]]*$/\1/p' openwrt/include/kernel.mk | head -n1)"
+        fi
+        [ -n "$vermagic" ] || vermagic="unknown"
+
+        {
+          echo "YAAWG version: ${{ inputs.amneziawg_version }}"
+          echo "OpenWrt version: ${{ inputs.openwrt_version }}"
+          echo "Target: ${{ inputs.openwrt_target }}/${{ inputs.openwrt_subtarget }}"
+          echo "Architecture: ${{ inputs.openwrt_arch }}"
+          echo "Built at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          echo "Vermagic: $vermagic"
+        } > awgrelease/build-info.txt
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v7

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -86,10 +86,17 @@ jobs:
           echo "CONFIG_PACKAGE_amneziawg-go=y" >> openwrt/.config
           echo "CONFIG_PACKAGE_amneziawg-tools=y" >> openwrt/.config
           echo "CONFIG_PACKAGE_luci-proto-amneziawg=y" >> openwrt/.config
-          # amneziawg-go requires Go 1.25.0 or newer, which most stable OpenWrt
-          # releases do not ship yet.
-          rm -r openwrt/feeds/packages/lang/golang
-          cp -r packages/lang/golang openwrt/feeds/packages/lang
+          # amneziawg-go requires Go >= 1.25. Only override the SDK's Go feed
+          # when it is actually too old.
+          sdk_go=$(sed -n 's/^GO_DEFAULT_VERSION:=//p' openwrt/feeds/packages/lang/golang/golang-values.mk)
+          need_go=1.25
+          if [ -n "$sdk_go" ] && [ "$(printf '%s\n%s\n' "$need_go" "$sdk_go" | sort -V | head -n1)" != "$need_go" ]; then
+            echo "SDK ships Go $sdk_go (< $need_go); overriding golang feed from openwrt/packages."
+            rm -r openwrt/feeds/packages/lang/golang
+            cp -r packages/lang/golang openwrt/feeds/packages/lang
+          else
+            echo "SDK ships Go ${sdk_go:-unknown} (>= $need_go); keeping the SDK golang feed."
+          fi
           ./openwrt/scripts/feeds install -a
           make -C openwrt defconfig
 
@@ -131,15 +138,23 @@ jobs:
           done
 
           # The kernel module can only be installed on a firmware whose kernel
-          # reports the very same vermagic, which matters for SNAPSHOT builds.
-          vermagic="$(find openwrt/build_dir -maxdepth 5 -type f -name '.vermagic' -print -quit)"
+          # reports the very same vermagic. Let's calculate it.
+          vermagic=""
+          vermagic_file="$(find openwrt/build_dir -maxdepth 5 -type f -name '.vermagic' -print -quit)"
+          if [ -n "$vermagic_file" ]; then
+            vermagic="$(cat "$vermagic_file")"
+          fi
+          if [ -z "$vermagic" ]; then
+            vermagic="$(sed -n 's/.*LINUX_VERMAGIC),\([^,)]*\))[[:space:]]*$/\1/p' openwrt/include/kernel.mk | head -n1)"
+          fi
+          [ -n "$vermagic" ] || vermagic="unknown"
           {
             echo "YAAWG version: ${{ inputs.amneziawg_version }}"
             echo "OpenWrt version: ${{ inputs.openwrt_version }}"
             echo "Target: ${{ inputs.openwrt_target }}/${{ inputs.openwrt_subtarget }}"
             echo "Architecture: $arch"
             echo "Built at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-            echo "Vermagic: $([ -n "$vermagic" ] && cat "$vermagic" || echo 'unknown')"
+            echo "Vermagic: $vermagic"
           } > awgrelease/build-info.txt
 
       - name: Upload artifacts

--- a/.github/workflows/build-toolchain-cache.yml
+++ b/.github/workflows/build-toolchain-cache.yml
@@ -95,8 +95,17 @@ jobs:
         if: ${{ inputs.update_go }}
         run: |
           set -e -x
-          rm -r openwrt/feeds/packages/lang/golang
-          cp -r packages/lang/golang openwrt/feeds/packages/lang
+          # amneziawg-go requires Go >= 1.25. Only override the source tree's Go
+          # feed when it is actually too old.
+          sdk_go=$(sed -n 's/^GO_DEFAULT_VERSION:=//p' openwrt/feeds/packages/lang/golang/golang-values.mk)
+          need_go=1.25
+          if [ -n "$sdk_go" ] && [ "$(printf '%s\n%s\n' "$need_go" "$sdk_go" | sort -V | head -n1)" != "$need_go" ]; then
+            echo "Tree ships Go $sdk_go (< $need_go); overriding golang feed from openwrt/packages."
+            rm -r openwrt/feeds/packages/lang/golang
+            cp -r packages/lang/golang openwrt/feeds/packages/lang
+          else
+            echo "Tree ships Go ${sdk_go:-unknown} (>= $need_go); keeping the tree's golang feed."
+          fi
 
       - name: Build toolchain and kernel
         run: |

--- a/README.md
+++ b/README.md
@@ -229,7 +229,8 @@ Key differences between the workflows:
 2. The new workflow uses the SDK instead of building the toolchain from scratch.
 3. The new workflow consists of a single step instead of two.
 4. The new workflow also compiles the localization package.
-5. The new workflow does not calculate `vermagic` value (see below).
+
+Both workflows record the `vermagic` value on the `Vermagic:` line of `build-info.txt` within the artifacts (see below).
 
 #### How to Use the New Workflow
 
@@ -308,6 +309,6 @@ Steps:
 > **Note:** You may need to clear your browser cache to see the new protocol available in OpenWRT.
 
 #### Vermagic control for `SNAPSHOT` versions
-> **Note:** The prebuilt `release` and `snapshot` archives record the `vermagic` in `build-info.txt`. Among the compile-it-yourself workflows only the **legacy** one computes it; the `New - Build AmneziaWG from SDK` workflow does not.
+> **Note:** Every workflow records the `vermagic` on the `Vermagic:` line of `build-info.txt` within the artifacts — the prebuilt `release` and `snapshot` archives as well as both compile-it-yourself workflows (`New - Build AmneziaWG from SDK` and the legacy one).
 
-Vermagic is a hash calculated for the OpenWRT kernel. When installing kernel-related packages, OpenWRT checks if the package's `vermagic` matches the kernel's. If not, installation won't succeed. Since `SNAPSHOT` versions update daily, `vermagic` values may differ. Check your firmware's `vermagic` by running `apk info kernel` or `opkg info kernel` and noting the hash after the kernel version in `Version`. For example, `6.6.52~f58afd3748410d3b1baa06a466d6682-r1` means `vermagic` is `f58afd3748410d3b1baa06a466d6682`. For the prebuilt archives the compiled package's `vermagic` value is recorded on the `Vermagic:` line of `build-info.txt`; in the legacy workflow it is placed in a separate `vermagic` file within the artifacts. If these do not match, the kernel module cannot be installed.
+Vermagic is a hash calculated for the OpenWRT kernel. When installing kernel-related packages, OpenWRT checks if the package's `vermagic` matches the kernel's. If not, installation won't succeed. Since `SNAPSHOT` versions update daily, `vermagic` values may differ. Check your firmware's `vermagic` by running `apk info kernel` or `opkg info kernel` and noting the hash after the kernel version in `Version`. For example, `6.6.52~f58afd3748410d3b1baa06a466d6682-r1` means `vermagic` is `f58afd3748410d3b1baa06a466d6682`. Every workflow records the compiled package's `vermagic` value on the `Vermagic:` line of `build-info.txt` within the artifacts. If these do not match, the kernel module cannot be installed.


### PR DESCRIPTION
Workflows:
- Fix Go version SDK overriding (override only when it is too old)
- Fix vermagic calculation and unify `build-info.txt` artifact

Readme:
- Update readme